### PR TITLE
Automatic update of xunit.runner.visualstudio to 2.4.2

### DIFF
--- a/src/Marqeta.Core.Abstractions.Tests/Marqeta.Core.Abstractions.Tests.csproj
+++ b/src/Marqeta.Core.Abstractions.Tests/Marqeta.Core.Abstractions.Tests.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="AutoFixture" Version="4.11.0" />
     <PackageReference Include="DeepEqual" Version="2.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
NuKeeper has generated a patch update of `xunit.runner.visualstudio` to `2.4.2` from `2.4.1`
`xunit.runner.visualstudio 2.4.2` was published at `2020-06-02T15:58:19Z`, 15 days ago

1 project update:
Updated `src\Marqeta.Core.Abstractions.Tests\Marqeta.Core.Abstractions.Tests.csproj` to `xunit.runner.visualstudio` `2.4.2` from `2.4.1`

[xunit.runner.visualstudio 2.4.2 on NuGet.org](https://www.nuget.org/packages/xunit.runner.visualstudio/2.4.2)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
