### PR TITLE
Automatic update of xunit.runner.visualstudio to 2.4.3

### DIFF
--- a/src/Marqeta.Core.Abstractions.Tests/Marqeta.Core.Abstractions.Tests.csproj
+++ b/src/Marqeta.Core.Abstractions.Tests/Marqeta.Core.Abstractions.Tests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="DeepEqual" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
NuKeeper has generated a patch update of `xunit.runner.visualstudio` to `2.4.3` from `2.4.2`
`xunit.runner.visualstudio 2.4.3` was published at `2020-08-03T14:08:03Z`, 12 days ago

1 project update:
Updated `src/Marqeta.Core.Abstractions.Tests/Marqeta.Core.Abstractions.Tests.csproj` to `xunit.runner.visualstudio` `2.4.3` from `2.4.2`

[xunit.runner.visualstudio 2.4.3 on NuGet.org](https://www.nuget.org/packages/xunit.runner.visualstudio/2.4.3)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
