### PR TITLE
Automatic update of System.ComponentModel.Annotations to 5.0.0

### DIFF
--- a/src/Marqeta.Core.Abstractions/Marqeta.Core.Abstractions.csproj
+++ b/src/Marqeta.Core.Abstractions/Marqeta.Core.Abstractions.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Diagnostics.Tools" Version="4.3.0" />
   </ItemGroup>
 


### PR DESCRIPTION
NuKeeper has generated a major update of `System.ComponentModel.Annotations` to `5.0.0` from `4.7.0`
`System.ComponentModel.Annotations 5.0.0` was published at `2020-11-09T23:38:04Z`, 12 days ago

1 project update:
Updated `src/Marqeta.Core.Abstractions/Marqeta.Core.Abstractions.csproj` to `System.ComponentModel.Annotations` `5.0.0` from `4.7.0`

[System.ComponentModel.Annotations 5.0.0 on NuGet.org](https://www.nuget.org/packages/System.ComponentModel.Annotations/5.0.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
