### PR TITLE
Automatic update of Microsoft.NET.Test.Sdk to 16.8.3

### DIFF
--- a/src/Marqeta.Core.Abstractions.Tests/Marqeta.Core.Abstractions.Tests.csproj
+++ b/src/Marqeta.Core.Abstractions.Tests/Marqeta.Core.Abstractions.Tests.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.11.0" />
     <PackageReference Include="DeepEqual" Version="2.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
NuKeeper has generated a minor update of `Microsoft.NET.Test.Sdk` to `16.8.3` from `16.7.1`
`Microsoft.NET.Test.Sdk 16.8.3` was published at `2020-12-02T22:48:17Z`, 10 days ago

1 project update:
Updated `src/Marqeta.Core.Abstractions.Tests/Marqeta.Core.Abstractions.Tests.csproj` to `Microsoft.NET.Test.Sdk` `16.8.3` from `16.7.1`

[Microsoft.NET.Test.Sdk 16.8.3 on NuGet.org](https://www.nuget.org/packages/Microsoft.NET.Test.Sdk/16.8.3)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
