### PR TITLE
Automatic update of AutoFixture to 4.15.0

### DIFF
--- a/src/Marqeta.Core.Abstractions.Tests/Marqeta.Core.Abstractions.Tests.csproj
+++ b/src/Marqeta.Core.Abstractions.Tests/Marqeta.Core.Abstractions.Tests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture" Version="4.11.0" />
+    <PackageReference Include="AutoFixture" Version="4.15.0" />
     <PackageReference Include="DeepEqual" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="xunit" Version="2.4.1" />


### PR DESCRIPTION
NuKeeper has generated a minor update of `AutoFixture` to `4.15.0` from `4.11.0`
`AutoFixture 4.15.0` was published at `2020-12-18T16:13:11Z`, 8 days ago

1 project update:
Updated `src/Marqeta.Core.Abstractions.Tests/Marqeta.Core.Abstractions.Tests.csproj` to `AutoFixture` `4.15.0` from `4.11.0`

[AutoFixture 4.15.0 on NuGet.org](https://www.nuget.org/packages/AutoFixture/4.15.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
