### PR TITLE
Automatic update of Newtonsoft.Json to 13.0.1

### DIFF
--- a/src/Marqeta.Core.Abstractions/Marqeta.Core.Abstractions.csproj
+++ b/src/Marqeta.Core.Abstractions/Marqeta.Core.Abstractions.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
     <PackageReference Include="System.Diagnostics.Tools" Version="4.3.0" />
   </ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a major update of `Newtonsoft.Json` to `13.0.1` from `12.0.3`
`Newtonsoft.Json 13.0.1` was published at `2021-03-22T20:10:49Z`, 12 days ago

1 project update:
Updated `src/Marqeta.Core.Abstractions/Marqeta.Core.Abstractions.csproj` to `Newtonsoft.Json` `13.0.1` from `12.0.3`

[Newtonsoft.Json 13.0.1 on NuGet.org](https://www.nuget.org/packages/Newtonsoft.Json/13.0.1)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
