### PR TITLE
Automatic update of Microsoft.NET.Test.Sdk to 17.2.0

### DIFF
--- a/src/Marqeta.Core.Abstractions.Tests/Marqeta.Core.Abstractions.Tests.csproj
+++ b/src/Marqeta.Core.Abstractions.Tests/Marqeta.Core.Abstractions.Tests.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture" Version="4.11.0" />
+    <PackageReference Include="AutoFixture" Version="4.17.0" />
     <PackageReference Include="DeepEqual" Version="2.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Marqeta.Core.Abstractions/Generated.cs
+++ b/src/Marqeta.Core.Abstractions/Generated.cs
@@ -17746,9 +17746,6 @@ namespace Marqeta.Core.Abstractions
         [System.Runtime.Serialization.EnumMember(Value = @"ICVV")]
         ICVV = 2,
     
-        [System.Runtime.Serialization.EnumMember(Value = @"DCVV")]
-        DCVV = 3,
-    
     }
     
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.3.9.0 (Newtonsoft.Json v11.0.0.0)")]

--- a/src/Marqeta.Core.Abstractions/Marqeta.Core.Abstractions.csproj
+++ b/src/Marqeta.Core.Abstractions/Marqeta.Core.Abstractions.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
     <PackageReference Include="System.Diagnostics.Tools" Version="4.3.0" />
   </ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a major update of `Microsoft.NET.Test.Sdk` to `17.2.0` from `16.7.1`
`Microsoft.NET.Test.Sdk 17.2.0` was published at `2022-05-11T09:07:34Z`, 10 days ago

1 project update:
Updated `src/Marqeta.Core.Abstractions.Tests/Marqeta.Core.Abstractions.Tests.csproj` to `Microsoft.NET.Test.Sdk` `17.2.0` from `16.7.1`

[Microsoft.NET.Test.Sdk 17.2.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.NET.Test.Sdk/17.2.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
