### PR TITLE
Automatic update of DeepEqual to 4.2.1

### DIFF
--- a/src/Marqeta.Core.Abstractions.Tests/Marqeta.Core.Abstractions.Tests.csproj
+++ b/src/Marqeta.Core.Abstractions.Tests/Marqeta.Core.Abstractions.Tests.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture" Version="4.11.0" />
-    <PackageReference Include="DeepEqual" Version="2.0.0" />
+    <PackageReference Include="AutoFixture" Version="4.17.0" />
+    <PackageReference Include="DeepEqual" Version="4.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">


### PR DESCRIPTION
NuKeeper has generated a major update of `DeepEqual` to `4.2.1` from `2.0.0`
`DeepEqual 4.2.1` was published at `2022-10-27T15:26:32Z`, 9 days ago

1 project update:
Updated `src/Marqeta.Core.Abstractions.Tests/Marqeta.Core.Abstractions.Tests.csproj` to `DeepEqual` `4.2.1` from `2.0.0`

[DeepEqual 4.2.1 on NuGet.org](https://www.nuget.org/packages/DeepEqual/4.2.1)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
